### PR TITLE
Add api endpoint to serve proxied images from grocy

### DIFF
--- a/custom_components/grocy/__init__.py
+++ b/custom_components/grocy/__init__.py
@@ -27,7 +27,8 @@ from .const import (
 )
 
 from .services import async_setup_services
-from .instance import GrocyInstance
+from .instance import GrocyInstance, async_setup_api
+from .helpers import MealPlanItem
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
 
@@ -66,6 +67,9 @@ async def async_setup_entry(hass, config_entry):
 
     # Setup services
     await async_setup_services(hass)
+
+    # Setup http endpoint for proxying images from grocy
+    await async_setup_api(hass, config_entry.data)
 
     return True
 

--- a/custom_components/grocy/helpers.py
+++ b/custom_components/grocy/helpers.py
@@ -1,12 +1,17 @@
+import base64
+
 class MealPlanItem(object):
-    def __init__(self, data, base_url):
+    def __init__(self, data):
         self.day = data.day
         self.note = data.note
         self.recipe_name = data.recipe.name
         self.desired_servings = data.recipe.desired_servings
 
-        picture_path = data.recipe.get_picture_url_path(400)
-        self.picture_url = f"{base_url}/api/{picture_path}"
+        if data.recipe.picture_file_name is not None:
+            b64name = base64.b64encode(data.recipe.picture_file_name.encode("ascii"))
+            self.picture_url = f"/api/grocy/recipepictures/{str(b64name, 'utf-8')}"
+        else:
+            self.picture_url = None
 
     def as_dict(self):
         return vars(self)

--- a/custom_components/grocy/manifest.json
+++ b/custom_components/grocy/manifest.json
@@ -2,7 +2,7 @@
   "domain": "grocy",
   "name": "Grocy",
   "documentation": "https://github.com/custom-components/grocy",
-  "dependencies": [],
+  "dependencies": ["http"],
   "config_flow": true,
   "codeowners": [
     "@SebRut",


### PR DESCRIPTION
This adds a api endpoint to serve proxied (no auth required) pictures from grocy. It'll cover all picture types in grocy.
Urls will be of the format: `http://homeassistant.local:8123/api/grocy/recipepictures/NTFzaTBxMHdzaXE1aW1vNGY4d2JJTUdfNTcwOS5qcGVn?width=500`
`width` is optional and defaults to 400 atm.

The meal_plan sensor have also been updated to reference images on this path.
Please review and see if this makes sense, python is not my strong suite and I don't know HA idioms well