### PR TITLE
Update to binary_sensor.grocy_overdue_chores. Count of how many chores are due

### DIFF
--- a/custom_components/grocy/entity.py
+++ b/custom_components/grocy/entity.py
@@ -127,7 +127,7 @@ class GrocyEntity(GrocyCoordinatorEntity):
         elif self.entity_type == GrocyEntityType.MISSING_PRODUCTS:
             data = {"missing": [x.as_dict() for x in self.entity_data]}
         elif self.entity_type == GrocyEntityType.OVERDUE_CHORES:
-            data = {"chores": [x.as_dict() for x in self.entity_data]}
+            data = {"chores": [x.as_dict() for x in self.entity_data], "count":len(self.entity_data)}
         elif self.entity_type == GrocyEntityType.OVERDUE_TASKS:
             data = {"tasks": [x.as_dict() for x in self.entity_data]}
         elif self.entity_type == GrocyEntityType.PRODUCTS:


### PR DESCRIPTION
Not sure if this is a useful attribute for other people, or if maybe the name should be something else than count. I use it in a TTS-script to tell myself every morning how many chores I have due today, and to give myself a reminder during the day if I still have chores undone.