### PR TITLE
Correct warning thrown from Home Assistant 2021.12.0b0

### DIFF
--- a/custom_components/grocy/entity.py
+++ b/custom_components/grocy/entity.py
@@ -1,6 +1,7 @@
 """GrocyEntity class"""
 import json
 from homeassistant.helpers import entity
+from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 # pylint: disable=relative-beyond-top-level
@@ -105,7 +106,7 @@ class GrocyEntity(GrocyCoordinatorEntity):
             "name": NAME,
             "model": VERSION,
             "manufacturer": NAME,
-            "entry_type": "service",
+            "entry_type": DeviceEntryType.SERVICE,
         }
 
     @property


### PR DESCRIPTION
`Detected code that uses str for device registry entry_type. This is deprecated and will stop working in Home Assistant 2022.3, it should be updated to use DeviceEntryType instead. Please report this issue.`