### PR TITLE
Allow Grocy instance on URL path

### DIFF
--- a/custom_components/grocy/__init__.py
+++ b/custom_components/grocy/__init__.py
@@ -15,6 +15,8 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from pygrocy import Grocy
 
+from .helpers import extract_base_url_and_path
+
 from .const import (
     CONF_API_KEY,
     CONF_PORT,
@@ -78,7 +80,10 @@ class GrocyDataUpdateCoordinator(DataUpdateCoordinator):
     def __init__(self, hass, url, api_key, port_number, verify_ssl):
         """Initialize."""
         super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=SCAN_INTERVAL)
-        self.api = Grocy(url, api_key, port_number, verify_ssl=verify_ssl)
+        (base_url, path) = extract_base_url_and_path(url)
+        self.api = Grocy(
+            base_url, api_key, path=path, port=port_number, verify_ssl=verify_ssl
+        )
         self.entities = []
         self.data = {}
 

--- a/custom_components/grocy/grocy_data.py
+++ b/custom_components/grocy/grocy_data.py
@@ -97,7 +97,7 @@ class GrocyData:
         """Get the configuration from Grocy."""
 
         def wrapper():
-            return self.client._api_client._do_get_request("/api/system/config")
+            return self.client._api_client._do_get_request("system/config")
 
         return await self.hass.async_add_executor_job(wrapper)
 

--- a/custom_components/grocy/helpers.py
+++ b/custom_components/grocy/helpers.py
@@ -1,4 +1,12 @@
 import base64
+from urllib.parse import urlparse
+from typing import Tuple
+
+
+def extract_base_url_and_path(url: str) -> Tuple[str, str]:
+    """Extract the base url and path from a given URL."""
+    parsed_url = urlparse(url)
+    return (f"{parsed_url.scheme}://{parsed_url.netloc}", parsed_url.path.strip("/"))
 
 
 class MealPlanItem(object):


### PR DESCRIPTION
Fixes #195.

- Also allows a Grocy instance installed on a URL with path, e.g. https://www.example.com/grocy. You can enter the full URL including the path.
- URL input is a bit more forgiving, it now ignores trailing slashes.
- GET requests to system endpoints wrongly had a /api prefix.
- Black formatting.