### PR TITLE
Add support for subproduct substitution

### DIFF
--- a/custom_components/grocy/services.py
+++ b/custom_components/grocy/services.py
@@ -18,6 +18,7 @@ SERVICE_PRODUCT_ID = "product_id"
 SERVICE_AMOUNT = "amount"
 SERVICE_PRICE = "price"
 SERVICE_SPOILED = "spoiled"
+SERVICE_SUBPRODUCT_SUBSTITUTION = "allow_subproduct_substitution"
 SERVICE_TRANSACTION_TYPE = "transaction_type"
 SERVICE_CHORE_ID = "chore_id"
 SERVICE_DONE_BY = "done_by"
@@ -47,6 +48,7 @@ SERVICE_CONSUME_PRODUCT_SCHEMA = vol.All(
             vol.Required(SERVICE_PRODUCT_ID): vol.Coerce(int),
             vol.Required(SERVICE_AMOUNT): vol.Coerce(float),
             vol.Optional(SERVICE_SPOILED): bool,
+            vol.Optional(SERVICE_SUBPRODUCT_SUBSTITUTION): bool,
             vol.Optional(SERVICE_TRANSACTION_TYPE): str,
         }
     )
@@ -173,6 +175,7 @@ async def async_consume_product_service(hass, coordinator, data):
     product_id = data[SERVICE_PRODUCT_ID]
     amount = data[SERVICE_AMOUNT]
     spoiled = data.get(SERVICE_SPOILED, False)
+    allow_subproduct_substitution = data.get(SERVICE_SUBPRODUCT_SUBSTITUTION, False)
 
     transaction_type_raw = data.get(SERVICE_TRANSACTION_TYPE, None)
     transaction_type = TransactionType.CONSUME
@@ -182,7 +185,11 @@ async def async_consume_product_service(hass, coordinator, data):
 
     def wrapper():
         coordinator.api.consume_product(
-            product_id, amount, spoiled=spoiled, transaction_type=transaction_type
+            product_id,
+            amount,
+            spoiled=spoiled,
+            transaction_type=transaction_type,
+            allow_subproduct_substitution=allow_subproduct_substitution,
         )
 
     await hass.async_add_executor_job(wrapper)

--- a/custom_components/grocy/services.yaml
+++ b/custom_components/grocy/services.yaml
@@ -54,6 +54,13 @@ consume_product_from_stock:
       default: false
       selector:
         boolean:
+    allow_subproduct_substitution:
+      name: Subproduct substitution
+      description: If subproduct substitution is allowed
+      example: false
+      default: false
+      selector:
+        boolean:
     transaction_type:
       name: Transaction Type
       description: The type of the transaction.


### PR DESCRIPTION
Fixes #182

Adds an option for subproduct substitution when consuming a product via the service consume_product_from_stock. False by default (current behavior).