### PR TITLE
Fix unloading config entry and services

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,13 +1,8 @@
 {
   "name": "Grocy custom component",
-  "domains": [
-    "sensor",
-    "binary_sensor"
-  ],
   "render_readme": true,
   "zip_release": true,
   "hide_default_branch": true,
-  "iot_class": "Cloud Polling",
   "homeassistant": "0.109.0",
   "filename": "grocy.zip"
 }


### PR DESCRIPTION
- Fix unloading the config entry and services. This never happened.
- Add a missing service to remove on unload. And some refactoring to make it less error prone.
- Remove the redundant _async_reload_entry_ method.

Reloading the integration or saving its system options, is now possible without restarting HA.

- Fix for failing HACS load check. Obsolete _domains_ and _iot_class_ in _hacs.json_.