### PR TITLE
Fix update version number in manifest file

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,17 +6,19 @@ on:
 
 jobs:
   release_zip_file:
-    name: Prepare release asset
+    name: Prepare and upload release asset
     runs-on: ubuntu-latest
+    env:
+      GROCY_ROOT_DIR: "${{ github.workspace }}/custom_components/grocy"
     steps:
       - name: Check out repository
         uses: actions/checkout@v1
 
-      # Get updated translations
       - name: Download Lokalise CLI
         run: |
           curl -sfL https://raw.githubusercontent.com/lokalise/lokalise-cli-2-go/master/install.sh | sh
-      - name: Downloading translations
+
+      - name: Download latest translations with Lokalise
         run: |
           ./bin/lokalise2 \
             --token "${{ secrets.lokalise_token }}"\
@@ -28,20 +30,21 @@ jobs:
             --export-sort a_z \
             --original-filenames=false  \
             --bundle-structure %LANG_ISO%.%FORMAT%
-      - name: Move new  translations
-        run: |
-          mkdir -p "${{ github.workspace }}/custom_components/grocy/translations/"
-          cp /tmp/lokalise/* "${{ github.workspace }}/custom_components/grocy/translations/"
-      - name: "Set version numbmer"
-        run: |
-          sed -i '/VERSION = /c\VERSION = "${{ github.ref }}"' "${{ github.workspace }}/custom_components/grocy/const.py"
-          sed -i 's|refs/heads/||' "${{ github.workspace }}/custom_components/grocy/const.py"
-          sed -i 's|refs/tags/||' "${{ github.workspace }}/custom_components/grocy/const.py"
 
-      # Pack the Grocy dir as a zip and upload to the release
-      - name: ZIP Grocy Dir
+      - name: Move downloaded translations
         run: |
-          cd "${{ github.workspace }}/custom_components/grocy"
+          mkdir -p "${{ env.GROCY_ROOT_DIR }}/translations/"
+          cp /tmp/lokalise/* "${{ env.GROCY_ROOT_DIR }}/translations/"
+
+      - name: Set release version number in files
+        run: |
+          sed -i '/VERSION = /c\VERSION = "${{ github.ref_name }}"' "${{ env.GROCY_ROOT_DIR }}/const.py"
+          (jq '.version = "${{ github.ref_name }}"' "${{ env.GROCY_ROOT_DIR }}/manifest.json") > "${{ env.GROCY_ROOT_DIR }}/manifest.json.tmp"
+          mv "${{ env.GROCY_ROOT_DIR }}/manifest.json.tmp" "${{ env.GROCY_ROOT_DIR }}/manifest.json"
+
+      - name: Add Grocy folder to zip archive
+        run: |
+          cd "${{ env.GROCY_ROOT_DIR }}"
           zip grocy.zip -r ./
 
       - name: Upload release asset
@@ -50,6 +53,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: "${{ github.workspace }}/custom_components/grocy/grocy.zip"
+          asset_path: "${{ env.GROCY_ROOT_DIR }}/grocy.zip"
           asset_name: grocy.zip
           asset_content_type: application/zip

--- a/custom_components/grocy/const.py
+++ b/custom_components/grocy/const.py
@@ -4,7 +4,7 @@ from enum import Enum
 # Base component constants
 NAME = "Grocy"
 DOMAIN = "grocy"
-VERSION = "v3.2.0"
+VERSION = "0.0.0"
 
 ISSUE_URL = "https://github.com/custom-components/grocy/issues"
 
@@ -73,4 +73,3 @@ class GrocyEntityIcon(str, Enum):
     SHOPPING_LIST = "mdi:cart-outline"
     STOCK = "mdi:fridge-outline"
     TASKS = "mdi:checkbox-marked-circle-outline"
-

--- a/custom_components/grocy/manifest.json
+++ b/custom_components/grocy/manifest.json
@@ -16,6 +16,6 @@
     "iso8601==0.1.12",
     "integrationhelper==0.2.2"
   ],
-  "version": "v3.0.1",
+  "version": "0.0.0",
   "iot_class": "local_polling"
 }


### PR DESCRIPTION
The release pipeline does not update the version value in the manifest.json. This should be the release version.
For example, it is used in [this](https://analytics.home-assistant.io/custom_integrations.json) analytics overview.

- Transform the manifest.json and set the version number in release pipeline.

- Set default version to 0.0.0, this makes the dev version recognizable.

- Simplify the const.py transformation in release pipeline.
The `github.ref_name` context property value is equal to the `github.ref` value but without the refs/.... prefix.
Can be removed later in favor of using the manifest file in code.

- Use env var for repeating file path in release pipeline.

- Naming.