### PR TITLE
Clean up, set minimal HA version to 2021.12.0

### DIFF
--- a/custom_components/grocy/__init__.py
+++ b/custom_components/grocy/__init__.py
@@ -4,14 +4,12 @@ Custom integration to integrate Grocy with Home Assistant.
 For more details about this integration, please refer to
 https://github.com/custom-components/grocy
 """
-import asyncio
 import logging
 from datetime import timedelta
 from typing import Any, List
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import Config, HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from pygrocy import Grocy
 
@@ -35,11 +33,6 @@ SCAN_INTERVAL = timedelta(seconds=30)
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup(_hass: HomeAssistant, _config: Config):
-    """Set up this integration using YAML is not supported."""
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     """Set up this integration using UI."""
     hass.data.setdefault(DOMAIN, {})
@@ -53,10 +46,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
         config_entry.data[CONF_VERIFY_SSL],
     )
 
-    await coordinator.async_refresh()
-
-    if not coordinator.last_update_success:
-        raise ConfigEntryNotReady
+    await coordinator.async_config_entry_first_refresh()
 
     hass.data[DOMAIN] = coordinator
 

--- a/custom_components/grocy/grocy_data.py
+++ b/custom_components/grocy/grocy_data.py
@@ -1,7 +1,6 @@
 from aiohttp import hdrs, web
-from datetime import timedelta, datetime
+from datetime import datetime
 import logging
-import pytz
 
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -14,10 +13,7 @@ from .const import (
 )
 from .helpers import MealPlanItem, extract_base_url_and_path
 
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
 _LOGGER = logging.getLogger(__name__)
-
-utc = pytz.UTC
 
 
 class GrocyData:
@@ -87,8 +83,8 @@ class GrocyData:
         overdue_chores = []
         for chore in chores:
             if chore.next_estimated_execution_time:
-                now = datetime.now().replace(tzinfo=utc)
-                due = chore.next_estimated_execution_time.replace(tzinfo=utc)
+                now = datetime.now()
+                due = chore.next_estimated_execution_time
                 if due < now:
                     overdue_chores.append(chore)
         return overdue_chores
@@ -132,7 +128,7 @@ class GrocyData:
         """Update data."""
         # This is where the main logic to update platform data goes.
         def wrapper():
-            return self.client.expiring_products(True)
+            return self.client.due_products(True)
 
         return await self.hass.async_add_executor_job(wrapper)
 

--- a/custom_components/grocy/manifest.json
+++ b/custom_components/grocy/manifest.json
@@ -12,9 +12,7 @@
     "@isabellaalstrom"
   ],
   "requirements": [
-    "pygrocy==1.2.1",
-    "iso8601==0.1.12",
-    "integrationhelper==0.2.2"
+    "pygrocy==1.2.1"
   ],
   "version": "v3.0.1",
   "iot_class": "local_polling"

--- a/custom_components/grocy/services.py
+++ b/custom_components/grocy/services.py
@@ -3,15 +3,11 @@ from __future__ import annotations
 
 import asyncio
 import voluptuous as vol
-import iso8601
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import entity_component
 
-from pygrocy import TransactionType
-from pygrocy import EntityType
-from datetime import datetime
+from pygrocy import TransactionType, EntityType
 
 # pylint: disable=relative-beyond-top-level
 from .const import DOMAIN

--- a/hacs.json
+++ b/hacs.json
@@ -3,6 +3,6 @@
   "render_readme": true,
   "zip_release": true,
   "hide_default_branch": true,
-  "homeassistant": "0.109.0",
+  "homeassistant": "2021.12.0",
   "filename": "grocy.zip"
 }


### PR DESCRIPTION
- Clean up legacy code.

- Remove unused imports and package requirements.

- Remove the unnecessary datetime replace tzinfo.

- Replace the deprecated expiring_products.

**As of this version, at least Home Assistant 2021.12.0 is required to run this integration.**