### PR TITLE
Add support to consume a recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Consumes a given amount of a product from the stock.
 
 Executes the given chore with an optional timestamp and executor.
 
+- **Grocy: Consume Recipe** (_grocy.consume_recipe_)
+
+Consumes the given recipe.
+
 
 # Translations
 

--- a/custom_components/grocy/services.yaml
+++ b/custom_components/grocy/services.yaml
@@ -146,3 +146,15 @@ add_generic:
       default: {"name": "Task name", "due_date": "2021-05-21"}
       selector:
         object:
+
+consume_recipe:
+  name: Consume Recipe
+  description: Consumes the given recipe
+  fields:
+    recipe_id:
+      name: Recipe Id
+      example: '3'
+      required: true
+      description: The id of the recipe to consume
+      selector:
+        text:


### PR DESCRIPTION
- Add service in Home Assistant to consume a recipe in Grocy.

Fixes #145 

Requires pygrocy 1.4.0 in PR #234