### PR TITLE
Fix broken Python 3.9 support

### DIFF
--- a/custom_components/grocy/helpers.py
+++ b/custom_components/grocy/helpers.py
@@ -1,4 +1,5 @@
 """Helpers for Grocy."""
+from __future__ import annotations
 
 import base64
 from typing import Any, Dict, Tuple


### PR DESCRIPTION
Python 3.9 support was broken with #233.

Fixes #243 (see https://github.com/custom-components/grocy/issues/243#issuecomment-1215588606)