### PR TITLE
Disable parallel updates

### DIFF
--- a/custom_components/grocy/binary_sensor.py
+++ b/custom_components/grocy/binary_sensor.py
@@ -33,6 +33,7 @@ from .grocy_data import GrocyData
 _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(seconds=300)
+PARALLEL_UPDATES = 1
 
 
 async def async_setup_entry(

--- a/custom_components/grocy/sensor.py
+++ b/custom_components/grocy/sensor.py
@@ -39,6 +39,7 @@ from .grocy_data import GrocyData
 _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(seconds=60)
+PARALLEL_UPDATES = 1
 
 
 async def async_setup_entry(


### PR DESCRIPTION
Have seen some random "updating sensor took too long" errors. Most likely caused by the parallel updates in latest beta, requiring changes in pygrocy as well. This small change disables parallel updates.