### PR TITLE
Use async_forward_entry_setups in async_setup_entry

### DIFF
--- a/custom_components/grocy/__init__.py
+++ b/custom_components/grocy/__init__.py
@@ -49,7 +49,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN] = coordinator
 
-    hass.config_entries.async_setup_platforms(config_entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
     await async_setup_services(hass, config_entry)
     await async_setup_endpoint_for_image_proxy(hass, config_entry.data)
 


### PR DESCRIPTION
Could this perhaps close #259 ?

Is it just this simple to move from calling async_setup_platforms, to awaiting async_forward_entry_setups? I haven't tested this personally and I'm not very familiar; hope this saves some time though.