### PR TITLE
Refresh chores/tasks after a generic service

### DIFF
--- a/custom_components/grocy/services.py
+++ b/custom_components/grocy/services.py
@@ -289,6 +289,7 @@ async def async_add_generic_service(hass, coordinator, data):
         coordinator.grocy_api.add_generic(entity_type, data)
 
     await hass.async_add_executor_job(wrapper)
+    await post_generic_refresh(coordinator, entity_type);
 
 
 async def async_update_generic_service(hass, coordinator, data):
@@ -307,6 +308,7 @@ async def async_update_generic_service(hass, coordinator, data):
         coordinator.grocy_api.update_generic(entity_type, object_id, data)
 
     await hass.async_add_executor_job(wrapper)
+    await post_generic_refresh(coordinator, entity_type);
 
 
 async def async_delete_generic_service(hass, coordinator, data):
@@ -323,7 +325,12 @@ async def async_delete_generic_service(hass, coordinator, data):
         coordinator.grocy_api.delete_generic(entity_type, object_id)
 
     await hass.async_add_executor_job(wrapper)
+    await post_generic_refresh(coordinator, entity_type);
 
+
+async def post_generic_refresh(coordinator, entity_type):
+    if entity_type == "tasks" or entity_type == "chores":
+        await _async_force_update_entity(coordinator, entity_type)
 
 async def async_consume_recipe_service(hass, coordinator, data):
     """Consume a recipe in Grocy."""


### PR DESCRIPTION
After calling a generic service for chores or tasks, force refresh their data. 

Mainly did this to improve the response time after adding a task through the lovelace card UI, so that it visually appears in the list quickly. But could be useful for other service calls as well. 

It could apply to other entity types other than chores or tasks, but I don't know as much about them so I'm not sure which are valid entities for force_update_entity. 

Fix #266 

