### PR TITLE
fix: change `software_version` to `sw_version` in entity.py

### DIFF
--- a/custom_components/grocy/entity.py
+++ b/custom_components/grocy/entity.py
@@ -37,7 +37,7 @@ class GrocyEntity(CoordinatorEntity[GrocyDataUpdateCoordinator]):
             identifiers={(DOMAIN, self.coordinator.config_entry.entry_id)},
             name=NAME,
             manufacturer=NAME,
-            software_version=VERSION,
+            sw_version=VERSION,
             entry_type=DeviceEntryType.SERVICE,
         )
 


### PR DESCRIPTION
Bug fix related to Home Assistant 2023.8.x

fixes #279 