### PR TITLE
Update pygrocy dependency to solve breaking changes from v4.0 API 

### DIFF
--- a/custom_components/grocy/manifest.json
+++ b/custom_components/grocy/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/custom-components/grocy/issues",
   "requirements": [
-    "pygrocy==1.5.0"
+    "pygrocy==2.0.0"
   ],
   "version": "0.0.0"
 }


### PR DESCRIPTION
`pygrocy` is now updated with the Product class fixes for the breaking changes from removal of the quantity unit conversion factors. Updating the manifest file to push through the pygrocy changes here. This will solve #281 .