### PR TITLE
Handle Grocy not ready/running with ConfigEntryNotReady

### DIFF
--- a/custom_components/grocy/__init__.py
+++ b/custom_components/grocy/__init__.py
@@ -11,6 +11,7 @@ from typing import List
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import PlatformNotReady
 
 from .const import (
     ATTR_BATTERIES,
@@ -40,11 +41,13 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     """Set up this integration using UI."""
     _LOGGER.info(STARTUP_MESSAGE)
-
-    coordinator: GrocyDataUpdateCoordinator = GrocyDataUpdateCoordinator(hass)
-    coordinator.available_entities = await _async_get_available_entities(
-        coordinator.grocy_data
-    )
+    try:
+        coordinator: GrocyDataUpdateCoordinator = GrocyDataUpdateCoordinator(hass)
+        coordinator.available_entities = await _async_get_available_entities(
+            coordinator.grocy_data
+        )
+    except ConnectionError as ex:
+        raise PlatformNotReady(f"Connection error while connecting to {device.ipaddr}: {ex}") from ex
     await coordinator.async_config_entry_first_refresh()
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN] = coordinator

--- a/custom_components/grocy/__init__.py
+++ b/custom_components/grocy/__init__.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 import logging
 from typing import List
 
+from requests.exceptions import JSONDecodeError
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import PlatformNotReady
+from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import (
     ATTR_BATTERIES,
@@ -47,7 +49,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
             coordinator.grocy_data
         )
     except ConnectionError as ex:
-        raise PlatformNotReady(f"Connection error while connecting to {device.ipaddr}: {ex}") from ex
+        raise ConfigEntryNotReady(
+            f"Connection error while connecting to Grocy: {ex}"
+        ) from ex
+    except JSONDecodeError as ex:
+        raise ConfigEntryNotReady(
+            f"Invalid response from Grocy, is Add-on running?: {ex}"
+        ) from ex
     await coordinator.async_config_entry_first_refresh()
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN] = coordinator

--- a/custom_components/grocy/__init__.py
+++ b/custom_components/grocy/__init__.py
@@ -9,11 +9,10 @@ from __future__ import annotations
 import logging
 from typing import List
 
-from requests.exceptions import JSONDecodeError
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from requests.exceptions import JSONDecodeError
 
 from .const import (
     ATTR_BATTERIES,


### PR DESCRIPTION
Raise approriate Exceptions for Home Assistant to know to retry when Grocy is not running or ready.

I've observed two cases:

1. Connection error, this can happen when there is no response, either due to some connection issue or (more likely) after a HAOS update and if the nginx reverse proxy addon is being used to handle SSL for grocy and hasn't started up yet and/or local DNS (again running under HAOS) hasn't started up after an update (this is when I first spotted the issue).
2. Invlaid/empty response, pygrocy doesn't check the content is present before trying to decode the json so we see `JSONDecodeError` at our end. This happens if the addon is not running.