### PR TITLE
bug fix: improper definition of voluptuous schema for new shopping list service

### DIFF
--- a/custom_components/grocy/services.py
+++ b/custom_components/grocy/services.py
@@ -135,7 +135,7 @@ SERVICE_TRACK_BATTERY_SCHEMA = vol.All(
     )
 )
 
-SERVICE_ADD_MISSING_PRODUCTS_TO_SHOPPING_LIST_SCHEMA: vol.All(
+SERVICE_ADD_MISSING_PRODUCTS_TO_SHOPPING_LIST_SCHEMA = vol.All(
     vol.Schema(
         {
             vol.Optional(SERVICE_LIST_ID): vol.Coerce(int),


### PR DESCRIPTION
missed an equals sign and entered a semi-colon instead. new service schema is defined properly