### PR TITLE
Update pygrocy to 2.4.1

### DIFF
--- a/custom_components/grocy/manifest.json
+++ b/custom_components/grocy/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/custom-components/grocy/issues",
   "requirements": [
-    "pygrocy2==2.4.0"
+    "pygrocy2==2.4.1"
   ],
   "version": "0.0.0"
 }


### PR DESCRIPTION
Updates pydantic to 2.11, which is compatible with HA 2025.5+

Fixes #344 